### PR TITLE
fix vncproxy on windows 2008 rfb proto parse bug

### DIFF
--- a/encodings/enc-tight.go
+++ b/encodings/enc-tight.go
@@ -142,7 +142,7 @@ func handleTightFilters(subencoding uint8, pixelFmt *common.PixelFormat, rect *c
 			return
 		}
 
-		paletteSize := colorCount + 1 // add one more
+		paletteSize := int(colorCount) + 1 // add one more
 		logger.Debugf("handleTightFilters: ----PALETTE_FILTER: paletteSize=%d bytesPixel=%d\n", paletteSize, bytesPixel)
 		//complete palette
 		_, err = r.ReadBytes(int(paletteSize) * bytesPixel)


### PR DESCRIPTION
Uint8 value range out of bounds causes problems in the parsing protocol