### PR TITLE
Fix nil reference error for color map message

### DIFF
--- a/client/server-messages.go
+++ b/client/server-messages.go
@@ -129,7 +129,7 @@ type MsgSetColorMapEntries struct {
 }
 
 func (fbm *MsgSetColorMapEntries) CopyTo(r io.Reader, w io.Writer, c common.IClientConn) error {
-	reader := &common.RfbReadHelper{Reader: r}
+	reader := common.NewRfbReadHelper(r)
 	writeTo := &WriteTo{w, "MsgSetColorMapEntries.CopyTo"}
 	reader.Listeners.AddListener(writeTo)
 	_, err := fbm.Read(c, reader)


### PR DESCRIPTION
I got an nil reference error with color map message processing on: github.com/amitbet/vncproxy v0.0.0-20191219055600-1c052273de0c
due to `reader.Listeners` is not initialized.

```
goroutine 8 [running]:
testing.tRunner.func1(0xc0000e2200)
        /go/src/testing/testing.go:874 +0x3a3
panic(0x706380, 0x9d7bc0)
        /go/src/runtime/panic.go:679 +0x1b2
github.com/amitbet/vncproxy/common.(*MultiListener).AddListener(...)
        /vncproxy/common/multi-listener.go:8
github.com/amitbet/vncproxy/client.(*MsgSetColorMapEntries).CopyTo(0xc0001441e0, 0x7d5680, 0xc0000fe120, 0x7d5700, 0xc000120000, 0x7f5bfb9ff398, 0xc0000fe120, 0xc0000b8690, 0x100) 
        /vncproxy/client/server-messages.go:134 +0xae
github.com/amitbet/vncproxy/player.(*FBSPlayListener).sendFbsMessage(0xc000122150)
        /vncproxy/player/fbs-play-listener.go:107 +0x3a9
github.com/amitbet/vncproxy/player.(*FBSPlayListener).Consume(0xc000122150, 0xc0003d3d00, 0x40e428, 0x40)
        /vncproxy/player/fbs-play-listener.go:77 +0x183
github.com/amitbet/vncproxy/common.(*MultiListener).Consume(0xc00011a020, 0xc0003d3d00, 0x2c, 0xc000115bc0)
        /vncproxy/common/multi-listener.go:14 +0x6f
```