### PR TITLE
reMarkable 2.10 authentication support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.17
+
+WORKDIR $GOPATH/src/github.com/amitbet/vncproxy
+
+RUN mkdir -p $GOPATH/src/github.com/amitbet/vncproxy
+COPY . .
+
+RUN cd $GOPATH/src/github.com/amitbet/vncproxy/recorder/cmd && \
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /recorder .
+RUN cd $GOPATH/src/github.com/amitbet/vncproxy/proxy/cmd && \
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -ldflags="-s -w" -o /proxy .
+RUN cd $GOPATH/src/github.com/amitbet/vncproxy/player/cmd && \
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /player .
+
+FROM scratch
+COPY --from=0 /recorder /recorder
+COPY --from=0 /proxy /proxy
+COPY --from=0 /player /player
+
+EXPOSE 5900
+
+ENTRYPOINT ["/proxy"]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ An RFB proxy, written in go that can save and replay FBS files
 * Produces FBS files compatible with [tightvnc's rfb player](https://www.tightvnc.com/rfbplayer.php) (while using tight's default 3Byte color format)
 * Can also be used as:
     * A screen recorder vnc-client
-    * A replay server to show fbs recordings to connecting clients 
-    
+    * A replay server to show fbs recordings to connecting clients
+    * Authentication proxy for reMarkable tablet (2.10+)
+
 - Tested on tight encoding with:
     - Tightvnc (client + java client + server)
     - FBS player (tightVnc Java player)
@@ -16,7 +17,7 @@ An RFB proxy, written in go that can save and replay FBS files
     - ChickenOfTheVnc(client)
     - VineVnc(server)
     - TigerVnc(client)
-    - Qemu vnc(server) 
+    - Qemu vnc(server)
 
 
 ### Executables (see releases)
@@ -30,7 +31,7 @@ An RFB proxy, written in go that can save and replay FBS files
     proxy -recDir=./recordings/ -targHost=192.168.0.100 -targPort=5903 -targPass=@@@@@ -tcpPort=5903 -wsPort=5905 -vncPass=@!@!@!
 
 ### Code usage examples
-* player/main.go (fbs recording vnc client) 
+* player/main.go (fbs recording vnc client)
     * Connects as client, records to FBS file
 * proxy/proxy_test.go (vnc proxy with recording)
     * Listens to both Tcp and WS ports
@@ -39,6 +40,21 @@ An RFB proxy, written in go that can save and replay FBS files
 * player/player_test.go (vnc replay server)
     * Listens to Tcp & WS ports
     * Replays a hard-coded FBS file in normal speed to all connecting vnc clients
+
+### Examples of using with reMarkable
+* Simply run the proxy with the `-reMarkable DEVICE_ID` flag
+* To get the `DEVICE_ID`:
+    * Log into reMarkable via SSH
+    * Extract the `devicetoken` string (exclude the `@ByteArray` wrapper) the string from `/etc/remarkable.conf`
+    * Run the following Python snippet to decrypt the `devicetoken`:
+      ```
+      pip3 install --user PyJWT
+      python3 -c 'import sys,jwt;t=jwt.decode(sys.argv[1],options={"verify_signature":False});print(t)' '(DEVICE TOKEN HERE)'
+      ```
+    * In output, you should get a string starting with `auth0|`. The whole string is your device ID which should 
+      be passed to be `-reMarkable` flag.
+* After you should be able to connect to the reMarkable via the proxy with a normal
+  VNC client (tested with TightVNC)
 
 ## **Architecture**
 

--- a/client/client-conn.go
+++ b/client/client-conn.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/amitbet/vncproxy/common"
-	"github.com/amitbet/vncproxy/logger"
 	"io"
 	"net"
 	"unicode"
+
+	"github.com/amitbet/vncproxy/common"
+	"github.com/amitbet/vncproxy/logger"
 )
 
 // A ServerMessage implements a message sent from the server to the client.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/amitbet/vncproxy
 
 require golang.org/x/net v0.0.0-20181129055619-fae4c4e3ad76
+
+go 1.13

--- a/proxy/vnc-session.go
+++ b/proxy/vnc-session.go
@@ -16,12 +16,15 @@ const (
 )
 
 type VncSession struct {
-	Target         string
-	TargetHostname string
-	TargetPort     string
-	TargetPassword string
-	ID             string
-	Status         SessionStatus
-	Type           SessionType
-	ReplayFilePath string
+	Target             string
+	TargetHostname     string
+	TargetPort         string
+	TargetPassword     string
+	ID                 string
+	Status             SessionStatus
+	Type               SessionType
+	ReplayFilePath     string
+	RemarkableDeviceId string
+	TLS                bool
+	OverrideEncodings  []uint32
 }

--- a/server/client-messages.go
+++ b/server/client-messages.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/binary"
 	"io"
+
 	"github.com/amitbet/vncproxy/common"
 )
 
@@ -313,10 +314,10 @@ func (msg *MsgClientCutText) Write(c io.Writer) error {
 
 // MsgClientQemuExtendedKey holds the wire format message, for qemu keys
 type MsgClientQemuExtendedKey struct {
-	SubType  uint8   // sub type
-	IsDown   uint16 // button down indicator
-	KeySym   uint32 // key symbol
-	KeyCode  uint32 // key code
+	SubType uint8  // sub type
+	IsDown  uint16 // button down indicator
+	KeySym  uint32 // key symbol
+	KeyCode uint32 // key code
 }
 
 func (*MsgClientQemuExtendedKey) Type() common.ClientMessageType {


### PR DESCRIPTION
reMarkable 2.10 adds a Screen Sharing feature which uses VNC protocol (only 16-bit color + ZRLE). The authentication works via UDP broadcast and the requires the connecting device to send a correct response to a challenge. This adds support in VNC proxy to perform that function, so one can use a standard VNC client to connect (through the proxy).