### PR TITLE
Support for Serving on Generic net.Listener

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,10 +1,10 @@
 package server
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"net"
+
 	"github.com/amitbet/vncproxy/common"
 )
 
@@ -61,6 +61,10 @@ func TcpServe(url string, cfg *ServerConfig) error {
 	if err != nil {
 		log.Fatalf("Error listen. %v", err)
 	}
+	return NetListenerServe(ln, cfg)
+}
+
+func NetListenerServe(ln net.Listener, cfg *ServerConfig) error {
 	for {
 		c, err := ln.Accept()
 		if err != nil {
@@ -68,7 +72,6 @@ func TcpServe(url string, cfg *ServerConfig) error {
 		}
 		go attachNewServerConn(c, cfg, "dummySession")
 	}
-	return nil
 }
 
 func attachNewServerConn(c io.ReadWriter, cfg *ServerConfig, sessionId string) error {
@@ -79,7 +82,6 @@ func attachNewServerConn(c io.ReadWriter, cfg *ServerConfig, sessionId string) e
 	}
 
 	if err := ServerVersionHandler(cfg, conn); err != nil {
-		fmt.Errorf("err: %v\n", err)
 		conn.Close()
 		return err
 	}


### PR DESCRIPTION
## Support for Serving on Generic net.Listener

Adds the ability to initialize a `VncProxy` object with your own `net.Listener`.

#### Example:

Where `ln` is a `net.Listener` implementation

```
	proxy := &vncproxy.VncProxy{
		NetListener: ln,
		ProxyVncPassword: "server-password",
		SingleSession: &vncproxy.VncSession{
			TargetHostname: "127.0.0.1",
			TargetPort:     "5900",
			TargetPassword: "target-password"
			ID:             "dummySession",
			Status:         vncproxy.SessionStatusInit,
			Type:           vncproxy.SessionTypeProxyPass,
		},
		UsingSessions: false,
	}
```

This is useful to me because I have a listener that does end to end encryption and other additional functionality. It's basically a TCP connection with LOTS of middlewares - abstracted as a net.Listener. I would love for the vnc proxy to accept connections over this net.Listener.