### PR TITLE
support shared flag in 7.3.1 ClientInit message handler

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -25,7 +25,7 @@ type VncProxy struct {
 	sessionManager   *SessionManager
 }
 
-func (vp *VncProxy) createClientConnection(target string, vncPass string) (*client.ClientConn, error) {
+func (vp *VncProxy) createClientConnection(target string, vncPass string, shared bool) (*client.ClientConn, error) {
 	var (
 		nc  net.Conn
 		err error
@@ -48,7 +48,7 @@ func (vp *VncProxy) createClientConnection(target string, vncPass string) (*clie
 	clientConn, err := client.NewClientConn(nc,
 		&client.ClientConfig{
 			Auth:      authArr,
-			Exclusive: true,
+			Exclusive: !shared, // Use the shared flag from the client
 		})
 
 	if err != nil {
@@ -100,7 +100,7 @@ func (vp *VncProxy) newServerConnHandler(cfg *server.ServerConfig, sconn *server
 			target = session.TargetHostname + ":" + session.TargetPort
 		}
 
-		cconn, err := vp.createClientConnection(target, session.TargetPassword)
+		cconn, err := vp.createClientConnection(target, session.TargetPassword, sconn.IsShared())
 		if err != nil {
 			session.Status = SessionStatusError
 			logger.Errorf("Proxy.newServerConnHandler error creating connection: %s", err)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -346,10 +346,7 @@ func ServerClientInitHandler(cfg *ServerConfig, c *ServerConn) error {
 	if err := binary.Read(c, binary.BigEndian, &shared); err != nil {
 		return err
 	}
-	/* TODO
-	if shared != 1 {
-		c.SetShared(false)
-	}
-	*/
+	isShared := (shared & 1) != 0
+	c.SetShared(isShared)
 	return nil
 }

--- a/server/server-conn.go
+++ b/server/server-conn.go
@@ -33,6 +33,9 @@ type ServerConn struct {
 	// Width of the frame buffer in pixels, sent to the client.
 	fbWidth uint16
 
+	// Flag indicating if the connection is shared with other clients
+	shared bool
+
 	// The pixel format associated with the connection. This shouldn't
 	// be modified. If you wish to set a new pixel format, use the
 	// SetPixelFormat method.
@@ -145,6 +148,14 @@ func (c *ServerConn) SetWidth(w uint16) {
 }
 func (c *ServerConn) SetHeight(h uint16) {
 	c.fbHeight = h
+}
+
+func (c *ServerConn) SetShared(shared bool) {
+	c.shared = shared
+}
+
+func (c *ServerConn) IsShared() bool {
+	return c.shared
 }
 
 func (c *ServerConn) handle() error {

--- a/server/server.go
+++ b/server/server.go
@@ -89,6 +89,11 @@ func attachNewServerConn(c io.ReadWriter, cfg *ServerConfig, sessionId string) e
 		return err
 	}
 
+	if err := ServerClientInitHandler(cfg, conn); err != nil {
+		conn.Close()
+		return err
+	}
+
 	//run the handler for this new incoming connection from a vnc-client
 	//this is done before the init sequence to allow listening to server-init messages (and maybe even interception in the future)
 	err = cfg.NewConnHandler(cfg, conn)
@@ -97,10 +102,6 @@ func attachNewServerConn(c io.ReadWriter, cfg *ServerConfig, sessionId string) e
 		return err
 	}
 
-	if err := ServerClientInitHandler(cfg, conn); err != nil {
-		conn.Close()
-		return err
-	}
 
 	if err := ServerServerInitHandler(cfg, conn); err != nil {
 		conn.Close()


### PR DESCRIPTION
support shared flag in 7.3.1 ClientInit message handler. 
At now , vncproxy always connect with downstream vnc server with exclusive flag.
This fix that vncproxy can not support multiple clients connecting at the same time.
